### PR TITLE
Fix abrupt checks in DisposableStack.prototype.use

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -3607,11 +3607,11 @@ contributors: Ron Buckton, Ecma International
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
           1. If _value_ is neither *null* nor *undefined*, then
             1. If Type(_value_) is not Object, throw a *TypeError* exception.
-            1. Let _method_ be GetDisposeMethod(_value_, ~sync-dispose~).
+            1. Let _method_ be ? GetDisposeMethod(_value_, ~sync-dispose~).
             1. If _method_ is *undefined*, then
                 1. Throw a *TypeError* exception.
             1. Else,
-              1. Perform ? AddDisposableResource(_disposableStack_, _value_, ~sync-dispose~, _method_).
+              1. Perform ! AddDisposableResource(_disposableStack_, _value_, ~sync-dispose~, _method_).
           1. Return _value_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Currently in [DisposableStack.prototype.use](https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.use) it calls [GetDisposeMethod](https://tc39.es/proposal-explicit-resource-management/#sec-getdisposemethod) without checking for an abrupt completion.
This means that just checking `method` against `undefined` does not guarantee it to be a valid method.
This then breaks the type of `method` for [AddDisposableResource](https://tc39.es/proposal-explicit-resource-management/#sec-adddisposableresource-disposable-v-hint-disposemethod) and arguably the first check.

By checking for an abrupt completion on GetDisposeMethod first, we can then also gurantee that AddDisposableResource can no longer fail so we can assert this does not happen.


Just to go through the steps:
We call `AddDisposableResource` and know that: `value` is not null or undefined and in fact an Object, `method` is not `undefined`, present and Callable (via GetDisposeMethod).

So in [AddDisposableResource](https://tc39.es/proposal-explicit-resource-management/#sec-adddisposableresource-disposable-v-hint-disposemethod)
We take step 2.b, then 2.b.i passes as we have checked this in 4.a of [DisposableStack.prototype.use](https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.use).
Then in step 2.b.ii we call [CreateDisposableResource](https://tc39.es/proposal-explicit-resource-management/#sec-createdisposableresource).
Here we know that method is present and callable from GetDisposeMethod via [GetMethod](https://tc39.es/ecma262/#sec-getmethod) thus we go to step 2.a and pass it, returning a normal completion.